### PR TITLE
Convert slot machine to Vue 3 Composition API

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,62 +1,15 @@
-<!DOCTYPE HTML>
-<html>
-<head>
-    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
-    <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0"/>
-    <meta name="apple-mobile-web-app-capable" content="yes"/>
-    <meta name="apple-mobile-web-app-status-bar-style" content="black"/>
-
-    <meta name="interface" content="desktop"/>
-
-    <title>Slots</title>
-
-    <link href='http://fonts.googleapis.com/css?family=Slackey' rel='stylesheet' type='text/css'/>
-    <link type="text/css" rel="stylesheet" href="css/reset.css"/>
-    <link type="text/css" rel="stylesheet" href="css/slot.css"/>
-
-</head>
-<body>
-<div id="viewport">
-    <div id="container">
-        <div id="header">
-            <h1>Slots Machine</h1>
-
-            <h3>Play and Win</h3>
-        </div>
-        <div id="reels">
-            <canvas id="canvas1" width="70" height="300"></canvas>
-            <canvas id="canvas2" width="70" height="300"></canvas>
-            <canvas id="canvas3" width="70" height="300"></canvas>
-            <div id="overlay">
-                <div id="winline"></div>
-            </div>
-            <div id="results">
-                <div id="score">
-                    <span id="multiplier">0</span> x <img src="img/reel-icon-4.png"/>
-                </div>
-                <div id="status"></div>
-            </div>
-            <!-- Loading overlay -->
-            <div id="loading">
-                <p>Loading..</p>
-                <div id="progressbar">
-                    <div id="progress"></div>
-                </div>
-            </div>
-        </div>
-
-
-        <div id="buttons">
-            <div role="button" tabindex=“0” id="play" class="button button-default">Play</div>
-        </div>
-
-        <div id="audio_debug">Audio not supported</div>
-    </div>
-
-    <input id="debug" type="button" value="Toggle Reels"/>
-</div>
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-<script type="text/javascript" src="js/slot.js"></script>
-<script type="text/javascript">$(function () { SlotGame(); });</script>
-</body>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Slots Machine</title>
+    <link href="https://fonts.googleapis.com/css?family=Slackey" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/reset.css" />
+    <link rel="stylesheet" href="/css/slot.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "slot5",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "vue": "^3.4.0",
+    "grammy": "^1.19.2"
+  },
+  "devDependencies": {
+    "vite": "^5.1.0",
+    "typescript": "^5.4.0",
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vue-tsc": "^2.0.0"
+  }
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,7 @@
+<template>
+  <SlotMachine />
+</template>
+
+<script setup lang="ts">
+import SlotMachine from './components/SlotMachine.vue';
+</script>

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,0 +1,13 @@
+import { Bot } from 'grammy';
+
+const token = process.env.BOT_TOKEN || '<YOUR_TOKEN_HERE>';
+const bot = new Bot(token);
+
+bot.command('start', (ctx) => ctx.reply('Добро пожаловать в слот-машину!'));
+
+bot.command('spin', (ctx) => {
+  const result = Math.floor(Math.random() * 6) + 1;
+  ctx.reply(`Ваш результат: ${result}`);
+});
+
+bot.start();

--- a/src/components/SlotMachine.vue
+++ b/src/components/SlotMachine.vue
@@ -1,0 +1,147 @@
+<template>
+  <div id="viewport">
+    <div id="container">
+      <div id="header">
+        <h1>Slots Machine</h1>
+        <h3>Play and Win</h3>
+      </div>
+      <div id="reels">
+        <canvas ref="canvas1" width="70" height="300"></canvas>
+        <canvas ref="canvas2" width="70" height="300"></canvas>
+        <canvas ref="canvas3" width="70" height="300"></canvas>
+        <div id="overlay">
+          <div id="winline"></div>
+        </div>
+        <div id="results" v-show="showResult">
+          <div id="score">
+            <span id="multiplier">{{ matches }}</span> x
+            <img src="img/reel-icon-4.png" />
+          </div>
+          <div id="status">{{ statusText }}</div>
+        </div>
+        <div id="loading" v-if="loading">
+          <p>Loading..</p>
+          <div id="progressbar">
+            <div id="progress" :style="{ width: progress + '%' }"></div>
+          </div>
+        </div>
+      </div>
+      <div id="buttons">
+        <button id="play" class="button button-default" @click="start">Play</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, reactive } from 'vue';
+
+interface Item {
+  path: string;
+  id: string;
+  img?: HTMLImageElement;
+}
+
+const items: Item[] = [
+  { path: 'reel-icon-1', id: 'reel1' },
+  { path: 'reel-icon-2', id: 'reel2' },
+  { path: 'reel-icon-3', id: 'reel3' },
+  { path: 'reel-icon-4', id: 'reel4' },
+  { path: 'reel-icon-5', id: 'reel5' },
+  { path: 'reel-icon-6', id: 'reel6' }
+];
+
+const BLURB_TBL = ['No win!', 'Good!', 'Excellent!', 'JACKPOT!'];
+
+const canvas1 = ref<HTMLCanvasElement | null>(null);
+const canvas2 = ref<HTMLCanvasElement | null>(null);
+const canvas3 = ref<HTMLCanvasElement | null>(null);
+
+const loading = ref(true);
+const progress = ref(0);
+const showResult = ref(false);
+const matches = ref(0);
+const statusText = ref('');
+
+interface ReelState {
+  index: number;
+  timer?: number;
+}
+
+const reels = reactive<ReelState[]>([
+  { index: 0 },
+  { index: 0 },
+  { index: 0 }
+]);
+
+function draw(canvas: HTMLCanvasElement, item: Item) {
+  const ctx = canvas.getContext('2d')!;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.drawImage(item.img!, 3, 5);
+}
+
+async function preloadImages() {
+  let loaded = 0;
+  for (const item of items) {
+    await new Promise<void>((resolve) => {
+      const img = new Image();
+      img.src = `img/${item.path}.png`;
+      img.onload = () => {
+        item.img = img;
+        loaded++;
+        progress.value = (loaded / items.length) * 100;
+        resolve();
+      };
+    });
+  }
+}
+
+function stopReel(i: number) {
+  const reel = reels[i];
+  if (reel.timer) {
+    clearInterval(reel.timer);
+    reel.timer = undefined;
+  }
+  if (!reels.some(r => r.timer)) {
+    // all stopped
+    showResult.value = true;
+    const ids = reels.map(r => r.index);
+    if (ids[0] === ids[1] && ids[1] === ids[2]) {
+      matches.value = 3;
+    } else if (ids[0] === ids[1] || ids[1] === ids[2] || ids[0] === ids[2]) {
+      matches.value = 2;
+    } else {
+      matches.value = 0;
+    }
+    statusText.value = BLURB_TBL[matches.value];
+  }
+}
+
+function start() {
+  showResult.value = false;
+  matches.value = 0;
+  statusText.value = '';
+
+  [canvas1, canvas2, canvas3].forEach((c, i) => {
+    const canvas = c.value!;
+    const reel = reels[i];
+    if (reel.timer) clearInterval(reel.timer);
+    reel.timer = window.setInterval(() => {
+      reel.index = (reel.index + 1) % items.length;
+      draw(canvas, items[reel.index]);
+    }, 50);
+  });
+
+  setTimeout(() => stopReel(0), 2000);
+  setTimeout(() => stopReel(1), 3000);
+  setTimeout(() => stopReel(2), 4000);
+}
+
+onMounted(async () => {
+  await preloadImages();
+  loading.value = false;
+  draw(canvas1.value!, items[0]);
+  draw(canvas2.value!, items[1]);
+  draw(canvas3.value!, items[2]);
+});
+</script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#app');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"],
+    "types": ["vite/client"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  build: {
+    outDir: 'dist'
+  }
+});


### PR DESCRIPTION
## Summary
- switch index.html to Vite entry
- add Vue/Vite/TypeScript config
- create SlotMachine component using Composition API
- setup minimal grammY bot

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68885a6ce3148324ab7b4e29519d6cb9